### PR TITLE
Combine authorization config with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Ensure that a class implementing `org.radarbase.jersey.auth.ProjectService` is a
 The following variables will be fetched from environment variables if set:\
 `MANAGEMENT_PORTAL_CLIENT_ID` sets `AuthConfig.managementPortal.clientId`\
 `MANAGEMENT_PORTAL_CLIENT_SECRET` sets `AuthConfig.managementPortal.clientSecret`\
-`AUTH_KEYSTORE_PASSWORD` sets `AuthConfig.jwtKeystorePassword` 
-`DATABASE_URL` sets `DatabaseConfig.url`
-`DATABASE_USER` sets `DatabaseConfig.user`
+`AUTH_KEYSTORE_PASSWORD` sets `AuthConfig.jwtKeystorePassword`\
+`DATABASE_URL` sets `DatabaseConfig.url`\
+`DATABASE_USER` sets `DatabaseConfig.user`\
 `DATABASE_PASSWORD` sets `DatabaseConfig.password`
 
 This factory can then be specified in your main method, by adding it to your `MyConfigClass` definition:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    api("org.radarbase:radar-jersey:0.2.4")
+    api("org.radarbase:radar-jersey:0.3.0")
 }
 ```
 
@@ -54,7 +54,8 @@ class MyEnhancerFactory(private val config: MyConfigClass): EnhancerFactory {
             MyResourceEnhancer(),
             // RADAR OAuth2 enhancement
             ConfigLoader.Enhancers.radar(AuthConfig(
-                    managementPortalUrl = "http://...",
+                    managementPortal = MPConfig(
+                        url = "http://..."),
                     jwtResourceName = "res_MyResource")),
             // Use ManagementPortal OAuth implementation
             ConfigLoader.Enhancers.managementPortal,
@@ -83,7 +84,12 @@ class MyEnhancerFactory(private val config: MyConfigClass): EnhancerFactory {
     }
 }
 ```
-Ensure that a class implementing `org.radarbase.jersey.auth.ProjectService` is added to the binder.
+Ensure that a class implementing `org.radarbase.jersey.auth.ProjectService` is added to the binder. This is done automatically if you configure a `MPConfig.clientId` and `MPConfig.clientSecret`. Then the projects will be fetched from ManagementPortal.
+
+The following variables will be fetched from environment variables if set:\
+`MANAGEMENT_PORTAL_CLIENT_ID` sets `AuthConfig.managementPortal.clientId`\
+`MANAGEMENT_PORTAL_CLIENT_SECRET` sets `AuthConfig.managementPortal.clientSecret`\
+`AUTH_KEYSTORE_PASSWORD` sets `AuthConfig.jwtKeystorePassword` 
 
 This factory can then be specified in your main method, by adding it to your `MyConfigClass` definition:
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The following variables will be fetched from environment variables if set:\
 `MANAGEMENT_PORTAL_CLIENT_ID` sets `AuthConfig.managementPortal.clientId`\
 `MANAGEMENT_PORTAL_CLIENT_SECRET` sets `AuthConfig.managementPortal.clientSecret`\
 `AUTH_KEYSTORE_PASSWORD` sets `AuthConfig.jwtKeystorePassword` 
+`DATABASE_URL` sets `DatabaseConfig.url`
+`DATABASE_USER` sets `DatabaseConfig.user`
+`DATABASE_PASSWORD` sets `DatabaseConfig.password`
 
 This factory can then be specified in your main method, by adding it to your `MyConfigClass` definition:
 ```kotlin

--- a/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/DatabaseConfig.kt
+++ b/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/DatabaseConfig.kt
@@ -12,7 +12,23 @@ data class DatabaseConfig(
         val properties: Map<String, String> = emptyMap(),
         val liquibase: LiquibaseConfig = LiquibaseConfig(),
         val healthCheckValiditySeconds: Long = 60
-)
+) {
+    fun combineWithEnv(): DatabaseConfig {
+        var config = this
+
+        System.getenv("DATABASE_URL")?.let {
+            config = config.copy(url = it)
+        }
+        System.getenv("DATABASE_USER")?.let {
+            config = config.copy(user = it)
+        }
+        System.getenv("DATABASE_PASSWORD")?.let {
+            config = config.copy(password = it)
+        }
+
+        return config
+    }
+}
 
 data class LiquibaseConfig(
         val enable: Boolean = true,

--- a/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/DatabaseConfig.kt
+++ b/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/DatabaseConfig.kt
@@ -1,5 +1,7 @@
 package org.radarbase.jersey.hibernate.config
 
+import org.radarbase.jersey.config.letEnv
+
 
 data class DatabaseConfig(
         /** Classes that can be used in Hibernate queries. */
@@ -13,21 +15,10 @@ data class DatabaseConfig(
         val liquibase: LiquibaseConfig = LiquibaseConfig(),
         val healthCheckValiditySeconds: Long = 60
 ) {
-    fun combineWithEnv(): DatabaseConfig {
-        var config = this
-
-        System.getenv("DATABASE_URL")?.let {
-            config = config.copy(url = it)
-        }
-        System.getenv("DATABASE_USER")?.let {
-            config = config.copy(user = it)
-        }
-        System.getenv("DATABASE_PASSWORD")?.let {
-            config = config.copy(password = it)
-        }
-
-        return config
-    }
+    fun combineWithEnv(): DatabaseConfig = this
+            .letEnv("DATABASE_URL") { copy(url = it) }
+            .letEnv("DATABASE_USER") { copy(user = it) }
+            .letEnv("DATABASE_PASSWORD") { copy(password = it) }
 }
 
 data class LiquibaseConfig(

--- a/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/HibernateResourceEnhancer.kt
+++ b/radar-jersey-hibernate/src/main/kotlin/org/radarbase/jersey/hibernate/config/HibernateResourceEnhancer.kt
@@ -18,7 +18,7 @@ class HibernateResourceEnhancer(
     override val classes: Array<Class<*>> = arrayOf(DatabaseInitialization::class.java)
 
     override fun AbstractBinder.enhance() {
-        bind(databaseConfig)
+        bind(databaseConfig.combineWithEnv())
                 .to(DatabaseConfig::class.java)
 
         bind(DatabaseHealthMetrics::class.java)

--- a/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
+++ b/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
@@ -33,10 +33,7 @@ data class AuthConfig(
 ) {
     fun combineWithEnv(): AuthConfig = this
             .letEnv("AUTH_KEYSTORE_PASSWORD") { copy(jwtKeystorePassword = it) }
-            .run { managementPortal.combineWithEnv()
-                    .takeIf { it != managementPortal }
-                    ?.let { copy(managementPortal = it) }
-                    ?: this }
+            .copy(managementPortal = managementPortal.combineWithEnv())
 }
 
 data class MPConfig(

--- a/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
+++ b/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
@@ -29,7 +29,19 @@ data class AuthConfig(
         val jwtKeystoreAlias: String? = null,
         /** Key password for the key alias in the p12 keystore. */
         val jwtKeystorePassword: String? = null,
-        )
+) {
+    fun combineWithEnv(): AuthConfig {
+        var config = this;
+        val mpConfig = managementPortal.combineWithEnv()
+        if (mpConfig != managementPortal) {
+            config = config.copy(managementPortal = mpConfig)
+        }
+        System.getenv("AUTH_KEYSTORE_PASSWORD")?.let {
+            config = config.copy(jwtKeystorePassword = it)
+        }
+        return config
+    }
+}
 
 data class MPConfig(
         /** URL for the current service to find the ManagementPortal installation. */
@@ -43,10 +55,21 @@ data class MPConfig(
         /** Interval after which the list of subjects in a project should be refreshed (minutes). */
         val syncParticipantsIntervalMin: Long = 5,
 ) {
-        /** Interval after which the list of projects should be refreshed. */
-        @JsonIgnore
-        val syncProjectsInterval: Duration = Duration.ofMinutes(syncProjectsIntervalMin)
-        /** Interval after which the list of subjects in a project should be refreshed. */
-        @JsonIgnore
-        val syncParticipantsInterval: Duration = Duration.ofMinutes(syncParticipantsIntervalMin)
+    /** Interval after which the list of projects should be refreshed. */
+    @JsonIgnore
+    val syncProjectsInterval: Duration = Duration.ofMinutes(syncProjectsIntervalMin)
+    /** Interval after which the list of subjects in a project should be refreshed. */
+    @JsonIgnore
+    val syncParticipantsInterval: Duration = Duration.ofMinutes(syncParticipantsIntervalMin)
+
+    fun combineWithEnv(): MPConfig {
+        var config = this
+        System.getenv("MANAGEMENT_PORTAL_CLIENT_ID")?.let {
+            config = config.copy(clientId = it)
+        }
+        System.getenv("MANAGEMENT_PORTAL_CLIENT_SECRET")?.let {
+            config = config.copy(clientSecret = it)
+        }
+        return config
+    }
 }

--- a/src/main/kotlin/org/radarbase/jersey/config/ConfigLoader.kt
+++ b/src/main/kotlin/org/radarbase/jersey/config/ConfigLoader.kt
@@ -115,3 +115,10 @@ object ConfigLoader {
         val generalException = GeneralExceptionResourceEnhancer()
     }
 }
+
+
+fun <T> T.letEnv(key: String, copyProperty: T.(String) -> T): T {
+    return System.getenv(key)?.let {
+        copyProperty(it)
+    } ?: this
+}

--- a/src/main/kotlin/org/radarbase/jersey/config/ManagementPortalResourceEnhancer.kt
+++ b/src/main/kotlin/org/radarbase/jersey/config/ManagementPortalResourceEnhancer.kt
@@ -28,6 +28,7 @@ import javax.inject.Singleton
  */
 class ManagementPortalResourceEnhancer(private val config: AuthConfig) : JerseyResourceEnhancer {
     override fun AbstractBinder.enhance() {
+        val config = config.combineWithEnv()
         bindFactory(TokenValidatorFactory::class.java)
                 .to(TokenValidator::class.java)
                 .`in`(Singleton::class.java)

--- a/src/main/kotlin/org/radarbase/jersey/config/RadarJerseyResourceEnhancer.kt
+++ b/src/main/kotlin/org/radarbase/jersey/config/RadarJerseyResourceEnhancer.kt
@@ -43,7 +43,7 @@ class RadarJerseyResourceEnhancer(
     }
 
     override fun AbstractBinder.enhance() {
-        bind(config)
+        bind(config.combineWithEnv())
                 .to(AuthConfig::class.java)
 
         bind(OkHttpClient().newBuilder()


### PR DESCRIPTION
The following variables will be fetched from environment variables if set:\
`MANAGEMENT_PORTAL_CLIENT_ID` sets `AuthConfig.managementPortal.clientId`\
`MANAGEMENT_PORTAL_CLIENT_SECRET` sets `AuthConfig.managementPortal.clientSecret`\
`AUTH_KEYSTORE_PASSWORD` sets `AuthConfig.jwtKeystorePassword`\ 
`DATABASE_URL` sets `DatabaseConfig.url`\
`DATABASE_USER` sets `DatabaseConfig.user`\
`DATABASE_PASSWORD` sets `DatabaseConfig.password`