### PR TITLE
Release 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    api("org.radarbase:radar-jersey:0.3.1")
+    api("org.radarbase:radar-jersey:0.3.2")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = 'org.radarbase'
-    version = '0.3.1'
+    version = '0.3.2-SNAPSHOT'
 
     ext {
         jerseyVersion = "2.32"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = 'org.radarbase'
-    version = '0.3.2-SNAPSHOT'
+    version = '0.3.2'
 
     ext {
         jerseyVersion = "2.32"

--- a/radar-jersey-hibernate/src/test/kotlin/org/radarbase/jersey/hibernate/DatabaseHealthMetricsTest.kt
+++ b/radar-jersey-hibernate/src/test/kotlin/org/radarbase/jersey/hibernate/DatabaseHealthMetricsTest.kt
@@ -3,7 +3,10 @@ package org.radarbase.jersey.hibernate
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.radarbase.jersey.GrizzlyServer
@@ -38,8 +41,8 @@ internal class DatabaseHealthMetricsTest {
             client.newCall(Request.Builder()
                     .url("http://localhost:9091/health")
                     .build()).execute().use { response ->
-                MatcherAssert.assertThat(response.isSuccessful, Matchers.`is`(true))
-                MatcherAssert.assertThat(response.body?.string(), Matchers.equalTo("{\"status\":\"UP\",\"db\":{\"status\":\"UP\"}}"))
+                assertThat(response.isSuccessful, `is`(true))
+                assertThat(response.body?.string(), equalTo("{\"status\":\"UP\",\"db\":{\"status\":\"UP\"}}"))
             }
         } finally {
             server.shutdown()
@@ -92,8 +95,8 @@ internal class DatabaseHealthMetricsTest {
             client.newCall(Request.Builder()
                     .url("http://localhost:9091/health")
                     .build()).execute().use { response ->
-                MatcherAssert.assertThat(response.isSuccessful, Matchers.`is`(true))
-                MatcherAssert.assertThat(response.body?.string(), Matchers.equalTo("{\"status\":\"UP\",\"db\":{\"status\":\"UP\"}}"))
+                assertThat(response.isSuccessful, `is`(true))
+                assertThat(response.body?.string(), equalTo("{\"status\":\"UP\",\"db\":{\"status\":\"UP\"}}"))
             }
 
             // Disable database. Connections should now fail
@@ -103,8 +106,8 @@ internal class DatabaseHealthMetricsTest {
             client.newCall(Request.Builder()
                     .url("http://localhost:9091/health")
                     .build()).execute().use { response ->
-                MatcherAssert.assertThat(response.isSuccessful, Matchers.`is`(true))
-                MatcherAssert.assertThat(response.body?.string(), Matchers.equalTo("{\"status\":\"DOWN\",\"db\":{\"status\":\"DOWN\"}}"))
+                assertThat(response.isSuccessful, `is`(true))
+                assertThat(response.body?.string(), equalTo("{\"status\":\"DOWN\",\"db\":{\"status\":\"DOWN\"}}"))
             }
         } finally {
             server.shutdown()

--- a/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
+++ b/src/main/kotlin/org/radarbase/jersey/auth/AuthConfig.kt
@@ -10,6 +10,8 @@
 package org.radarbase.jersey.auth
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.radarbase.jersey.config.ConfigLoader.copyEnv
 import org.radarbase.jersey.config.ConfigLoader.copyOnChange
 import java.time.Duration
@@ -49,6 +51,12 @@ data class MPConfig(
         /** Interval after which the list of subjects in a project should be refreshed (minutes). */
         val syncParticipantsIntervalMin: Long = 5,
 ) {
+    @JsonIgnore
+    val httpUrl: HttpUrl? = url?.toHttpUrlOrNull()
+            ?.let { url ->
+                url.newBuilder().addPathSegment("").build()
+            }
+
     /** Interval after which the list of projects should be refreshed. */
     @JsonIgnore
     val syncProjectsInterval: Duration = Duration.ofMinutes(syncProjectsIntervalMin)

--- a/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClient.kt
+++ b/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClient.kt
@@ -25,8 +25,11 @@ class MPClient(
             ?: throw IllegalArgumentException("Cannot configure managementportal client without client ID")
     private val clientSecret: String = config.managementPortal.clientSecret
             ?: throw IllegalArgumentException("Cannot configure managementportal client without client secret")
-    private val baseUrl: HttpUrl = config.managementPortal.url?.toHttpUrlOrNull()
-            ?: throw MalformedURLException("Cannot parse base URL ${config.managementPortal.url} as an URL")
+    private val baseUrl: HttpUrl = (config.managementPortal.url?.toHttpUrlOrNull()
+            ?: throw MalformedURLException("Cannot parse base URL ${config.managementPortal.url} as an URL"))
+            .newBuilder()
+            .addPathSegment("")
+            .build()
 
     private val projectListReader = objectMapper.readerFor(object : TypeReference<List<MPProject>>() {})
     private val userListReader = objectMapper.readerFor(object : TypeReference<List<MPUser>>() {})

--- a/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClient.kt
+++ b/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClient.kt
@@ -40,7 +40,7 @@ class MPClient(
     private var token: RestOauth2AccessToken? = null
 
     private val validToken: RestOauth2AccessToken?
-    get() = token?.takeIf { it.isValid() }
+        get() = token?.takeIf { it.isValid() }
 
     private fun ensureToken(): String = (validToken
             ?: requestToken().also { token = it })

--- a/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPOAuthClient.kt
+++ b/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPOAuthClient.kt
@@ -1,0 +1,7 @@
+package org.radarbase.jersey.service.managementportal
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class MPOAuthClient(
+        @JsonProperty("clientId") val id: String,
+)

--- a/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPProject.kt
+++ b/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPProject.kt
@@ -15,4 +15,5 @@ data class MPProject(
         /** Project description. */
         val description: String? = null,
         /** Any other attributes. */
-        val attributes: Map<String, String> = emptyMap())
+        val attributes: Map<String, String> = emptyMap(),
+)

--- a/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPUser.kt
+++ b/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPUser.kt
@@ -13,4 +13,5 @@ data class MPUser(
         /** User status in the project. */
         val status: String = "DEACTIVATED",
         /** Additional attributes of the user. */
-        val attributes: Map<String, String> = emptyMap())
+        val attributes: Map<String, String> = emptyMap(),
+)


### PR DESCRIPTION
Changes since version 0.3.1:
- Make HibernateRepository more extensible
- Ensure that ManagementPortal base URL has trailing slash internally
- Add MPClient.readClients() method to read OAuthClients.