### PR TITLE
Fix mp client factory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 allprojects {
     group = "org.radarbase"
-    version = "0.9.3"
+    version = "0.9.4"
 }
 
 subprojects {

--- a/radar-jersey/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClientFactory.kt
+++ b/radar-jersey/src/main/kotlin/org/radarbase/jersey/service/managementportal/MPClientFactory.kt
@@ -14,7 +14,7 @@ class MPClientFactory(
 ) : Supplier<MPClient> {
     override fun get(): MPClient = MPClient(
         serverConfig = MPClient.MPServerConfig(
-            url = requireNotNull(authConfig.managementPortal.httpUrl) { "ManagementPortal client needs a URL" }.toString(),
+            url = requireNotNull(authConfig.managementPortal.url) { "ManagementPortal client needs a URL" }.toString(),
             clientId = requireNotNull(authConfig.managementPortal.clientId) { "ManagementPortal client needs a client ID" },
             clientSecret = requireNotNull(authConfig.managementPortal.clientSecret) { "ManagementPortal client needs a client secret" },
         ),


### PR DESCRIPTION
Errors were thrown in radar-backend when creating an MP client, as the httpUrl field always returned null.

I now configured MPClientfactory to not makeuse of the httpUrl but just use the url. This should not be incorporated in version >0.10

It also includes a new release to avoid incompatibility issues with other backports.