### PR TITLE
Fix malformed www-authenticate issue

### DIFF
--- a/radar-jersey/src/main/kotlin/org/radarbase/jersey/exception/HttpUnauthorizedException.kt
+++ b/radar-jersey/src/main/kotlin/org/radarbase/jersey/exception/HttpUnauthorizedException.kt
@@ -48,7 +48,7 @@ class HttpUnauthorizedException(
         private val headerFieldIllegalCharacters = "[^\\x20-\\x21\\x23-\\x5B\\x5D-\\x7E]".toRegex()
         private fun StringBuilder.appendHeaderField(name: String, value: String?) {
             value ?: return
-            append(' ')
+            append(", ")
             append(name)
             append("=\"")
             append(value.replace(headerFieldIllegalCharacters, "?"))


### PR DESCRIPTION
Our WWW-Authenticate headers were incorrectly formatted, reading 

```
     WWW-Authenticate: Bearer realm="example" error="invalid_token" error_description="The access token expired"
```

instead of 

```
     WWW-Authenticate: Bearer realm="example", error="invalid_token", error_description="The access token expired"
```

According to the [oauth2 spec](https://www.rfc-editor.org/rfc/rfc6750#section-3) and the [HTTP spec](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3).

This should fix the error