### PR TITLE
Impl. override of required config parameters

### DIFF
--- a/radar-jersey/src/test/kotlin/org/radarbase/jersey/config/ConfigLoaderTest.kt
+++ b/radar-jersey/src/test/kotlin/org/radarbase/jersey/config/ConfigLoaderTest.kt
@@ -2,14 +2,44 @@ package org.radarbase.jersey.config
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.radarbase.jersey.config.ConfigLoader.copyEnv
 
 internal class ConfigLoaderTest {
+
+    val testFile = javaClass.getResource("/config/test.yaml")?.file.toString()
+    val config = ConfigLoader.loadConfig<Config>(testFile, emptyArray())
+
     @Test
     fun loadConfig() {
-        val testFile = javaClass.getResource("/config/test.yaml")?.file.toString()
-        val config = ConfigLoader.loadConfig<Config>(testFile, emptyArray())
-        assertEquals(Config(mapOf("test" to "a")), config)
+        assertEquals(
+            NestedConfig(requiredArg = "a", optionalArg = "b"),
+            config.config,
+        )
     }
 
-    data class Config(val config: Map<String, String>)
+    @Test
+    fun testEnvOverride() {
+        assertEquals(
+            NestedConfig(requiredArg = "overridden_required_arg", optionalArg = "overridden_optional_arg"),
+            config.config.withEnv(),
+        )
+    }
+
+    data class NestedConfig(
+        val requiredArg: String,
+        val optionalArg: String?,
+    ) {
+        val envVarsMock = mapOf(
+            Pair("OPTIONAL_ARG", "overridden_optional_arg"),
+            Pair("REQUIRED_ARG", "overridden_required_arg"),
+        )
+
+        fun withEnv(): NestedConfig = this
+            .copyEnv("OPTIONAL_ARG", { envVarsMock[it] }) { copy(optionalArg = it) }
+            .copyEnv("REQUIRED_ARG", { envVarsMock[it] }) { copy(requiredArg = it) }
+    }
+
+    data class Config(
+        val config: NestedConfig,
+    )
 }

--- a/radar-jersey/src/test/resources/config/test.yaml
+++ b/radar-jersey/src/test/resources/config/test.yaml
@@ -1,2 +1,3 @@
 config:
-  test: a
+  requiredArg: a
+  optionalArg: b


### PR DESCRIPTION
# Problem
The existing _copyEnv_ function does not allow to override config options that are not nullable (required parameters)

# Solution
This PR will refactor the _copyEnv_ function to allow setting both nullable and non-nullable config options.

# Note
Tests were added to assert override of config by env vars.