### PR TITLE
Up management portal client version to 2.1.6

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -12,7 +12,7 @@ object Versions {
     const val mockitoKotlin = "5.2.1"
 
     const val hk2 = "3.0.5"
-    const val managementPortal = "2.1.0"
+    const val managementPortal = "2.1.6"
     const val radarCommons = "1.1.2"
     const val javaJwt = "4.4.0"
     const val jakartaWsRs = "3.1.0"


### PR DESCRIPTION
This version upgrade fixes a bug where whitespace in project names would cause an error in MPClient.