### PR TITLE
Add error message when reaching co-routine timeout for http requests

### DIFF
--- a/radar-jersey/src/main/kotlin/org/radarbase/jersey/coroutines/CoroutineRequestWrapper.kt
+++ b/radar-jersey/src/main/kotlin/org/radarbase/jersey/coroutines/CoroutineRequestWrapper.kt
@@ -44,7 +44,12 @@ class CoroutineRequestWrapper(
         timeout ?: return
         launch {
             delay(timeout)
-            emit(HttpServerUnavailableException())
+            emit(
+                HttpServerUnavailableException(
+                    "The co-routine that handles the request exceeded the max duration of " +
+                        "$timeout. The request timeout can be configured as parameter to the runAsCoroutine() or runBlocking() function.",
+                ),
+            )
         }
     }
 
@@ -63,7 +68,10 @@ data class CoroutineRequestConfig(
     var location: String? = null,
 )
 
-fun CoroutineRequestWrapper(requestScope: RequestScope? = null, block: CoroutineRequestConfig.(hasExistingScope: Boolean) -> Unit): CoroutineRequestWrapper {
+fun CoroutineRequestWrapper(
+    requestScope: RequestScope? = null,
+    block: CoroutineRequestConfig.(hasExistingScope: Boolean) -> Unit,
+): CoroutineRequestWrapper {
     var newlyCreated = false
     val requestContext = try {
         if (requestScope != null) {


### PR DESCRIPTION
# Problem
When the timeout is reached for http requests, runAsCoroutine returns a HttpServerUnavailableException without a message. This resulted in difficulty finding the source of the error for requests that are ok to take a longer time very difficult.

# Solution
This PR will add a message to the exception that clearly states the reason for the thrown timeout exception. 