### PR TITLE
release-0.12.4

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Publish
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
         run: ./gradlew -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Publish
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
         run: ./gradlew -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} publish closeAndReleaseSonatypeStagingRepository

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    api("org.radarbase:radar-jersey:0.12.2")
+    api("org.radarbase:radar-jersey:0.12.4")
 }
 ```
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "0.12.3"
+    const val project = "0.12.4"
     const val kotlin = "1.9.22"
 
     const val java: Int = 17


### PR DESCRIPTION
The release action that uploads artifacts to maven central of the previous release was broken. This release tries to fix the release.