### PR TITLE
Fix setting thread pool size config

### DIFF
--- a/radar-jersey/src/main/kotlin/org/radarbase/jersey/GrizzlyServer.kt
+++ b/radar-jersey/src/main/kotlin/org/radarbase/jersey/GrizzlyServer.kt
@@ -9,6 +9,7 @@
 
 package org.radarbase.jersey
 
+import org.glassfish.grizzly.threadpool.GrizzlyExecutorService
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
 import org.glassfish.jersey.server.ResourceConfig
@@ -45,10 +46,13 @@ class GrizzlyServer(
 
         if (workerCorePoolSize != null || workerMaxPoolSize != null) {
             listeners.forEach { listener ->
-                listener.transport.workerThreadPoolConfig = ThreadPoolConfig.defaultConfig().apply {
-                    workerCorePoolSize?.let(::setCorePoolSize)
-                    workerMaxPoolSize?.let(::setMaxPoolSize)
-                }
+                listener.transport.workerThreadPool = GrizzlyExecutorService.createInstance(
+                    ThreadPoolConfig.defaultConfig().apply {
+                        workerCorePoolSize?.let(::setCorePoolSize)
+                        workerMaxPoolSize?.let(::setMaxPoolSize)
+                        setPoolName("grizzly-http-server")
+                    },
+                )
             }
         }
     }


### PR DESCRIPTION
- The worker pool size config was assigned after `GrizzlyHttpServerFactory.createHttpServer()` had already created the default pool, so Grizzly ignored it
- This creates a new thread pool instance in order to override the pool size config